### PR TITLE
feat: auto-prefix relay URLs with "wss://" and change order of relay list retrieval in config.go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 
 # Expose the port that the application will run on
-EXPOSE 3334
+EXPOSE 3335
 
 # Set the command to run the executable
 CMD ["./main"]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ IMPORT_SEED_RELAYS_FILE=relays_import.json
 BLASTR_RELAYS_FILE=blastr_relays.json
 ```
 
-The JSON should contain an array of relay URLs (without ws:// or wss://):
+The JSON should contain an array of relay URLs:
 
 ```json
 [

--- a/config.go
+++ b/config.go
@@ -120,7 +120,11 @@ func getRelayListFromFile(filePath string) []string {
 	}
 
 	for i, relay := range relayList {
-		relayList[i] = "wss://" + strings.TrimSpace(relay)
+		relay = strings.TrimSpace(relay)
+		if !strings.HasPrefix(relay, "wss://") {
+			relay = "wss://" + relay
+		}
+		relayList[i] = relay
 	}
 	return relayList
 }

--- a/config.go
+++ b/config.go
@@ -53,13 +53,14 @@ type AwsConfig struct {
 
 func getRelayListFromEnvOrFile(envKey, fileKey string) []string {
 	envValue := getEnv(envKey)
-	if envValue != "" {
-		return getRelayList(envValue)
-	}
-
 	filePath := getEnv(fileKey)
+
 	if filePath != "" {
 		return getRelayListFromFile(filePath)
+	}
+
+	if envValue != "" {
+		return getRelayList(envValue)
 	}
 
 	return []string{}


### PR DESCRIPTION
Now the file is really taken if it is 
was specified. Of course there are now lots of errors and notices because there are relays in the large list that require Auth etc. The question is whether these relays could then be kicked out dynamically?