### PR TITLE
New Docker compose with Nginx + SSL Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,6 @@ AWS_BUCKET_NAME="backups"
 ## Blastr Settings
 BLASTR_RELAYS="relay.damus.io,nos.lol,relay.nostr.band,relay.snort.social,nostr.land,nostr.mom,relay.nos.social,relay.primal.net,relay.nostr.bg,no.str.cr,nostr21.com,nostrue.com,relay.siamstr.com,wot.utxo.one,nostrelites.org,wot.nostr.party,wot.sovbit.host,wot.girino.org,relay.lnau.net,wot.siamstr.com,wot.sudocarlos.com,relay.otherstuff.fyi,relay.lexingtonbitcoin.org,wot.azzamo.net,wot.swarmstr.com,zap.watch,satsage.xyz,wons.calva.dev"
 BLASTR_RELAYS_FILE="relays_blastr.json"
+
+# Docker
+ACME_EMAIL=mail@yourdomain.tld

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 relays_import.json
 relays_blastr.json
 haven
+.DS_Store
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN chown -R appuser:appgroup /app
 USER appuser
 
 # Expose the port that the application will run on
-EXPOSE 3334
+EXPOSE 3355
 
 # Set the command to run the executable
 CMD ["./main"]

--- a/README.md
+++ b/README.md
@@ -230,6 +230,24 @@ To start the project using Docker Compose, follow these steps:
 
 This will build the Docker image and start the `haven-relay` service as defined in the `docker-compose.yml` file. The application will be accessible on port 3335.
 
+### Nginx + SSL with Docker (optional)
+
+If you want to serve the relay over HTTPS, you can use Nginx as a reverse proxy with SSL termination.
+
+It's recommended to edit the `.env` file and modify the `EMAIL` to a real email address.
+
+You'll also need to expose ports 80 and 443 to the internet and set up your DNS A and AAAA (if you are using IPv6) 
+records to point to your server's IP address.
+
+Finally, run the following command:
+
+```sh
+# in foreground
+docker compose -f docker-compose-nginx-ssl.yml up --build
+# in background
+docker compose -f docker-compose-nginx-ssl.yml up --build -d
+```
+
 ### Hidden Service with Tor and Docker (optional)
 
 Same as the step 6, but with the following command:

--- a/docker-compose-nginx-ssl.yml
+++ b/docker-compose-nginx-ssl.yml
@@ -1,0 +1,69 @@
+services:
+  relay:
+    container_name: haven-relay
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    environment:
+      - LETSENCRYPT_HOST=${RELAY_URL}
+      - VIRTUAL_HOST=${RELAY_URL}
+      - VIRTUAL_PORT=3355
+    volumes:
+      - "./db:/app/db"
+      - "./haven:/app/haven"
+    user: "${DOCKER_UID:-1000}:${DOCKER_GID:-1000}"
+    network_mode: bridge
+    restart: unless-stopped
+
+  nginx-proxy:
+    image: nginx:alpine
+    container_name: nginx-proxy
+    volumes:
+      # The vhost volume is only required if you
+      # plan to obtain standalone certificates
+      # - vhost:/etc/nginx/vhost.d
+      - conf:/etc/nginx/conf.d
+      - html:/usr/share/nginx/html
+      - certs:/etc/nginx/certs:ro
+    ports:
+      - "80:80"
+      - "443:443"
+    network_mode: bridge
+    restart: unless-stopped
+
+  docker-gen:
+    image: nginxproxy/docker-gen
+    container_name: nginx-proxy-gen
+    command: -notify-sighup nginx-proxy -watch -wait 5s:30s /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    volumes_from:
+      - nginx-proxy
+    volumes:
+      - ./nginx/nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    labels:
+      - "com.github.nginx-proxy.docker-gen"
+    privileged: true
+    network_mode: bridge
+
+  acme-companion:
+    image: nginxproxy/acme-companion
+    container_name: nginx-proxy-acme
+    environment:
+      - DEFAULT_EMAIL=${ACME_EMAIL}
+    volumes_from:
+      - nginx-proxy
+    volumes:
+      - certs:/etc/nginx/certs:rw
+      - acme:/etc/acme.sh
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    privileged: true
+    network_mode: bridge
+
+volumes:
+  # vhost:
+  conf:
+  html:
+  certs:
+  acme:

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -1,0 +1,899 @@
+# nginx-proxy{{ if $.Env.NGINX_PROXY_VERSION }} version : {{ $.Env.NGINX_PROXY_VERSION }}{{ end }}
+
+{{- /*
+     * Global values.  Values are stored in this map rather than in individual
+     * global variables so that the values can be easily passed to embedded
+     * templates.  (Go templates cannot access variables outside of their own
+     * scope.)
+     */}}
+{{- $globals := dict }}
+{{- $_ := set $globals "containers" $ }}
+{{- $_ := set $globals "Env" $.Env }}
+{{- $_ := set $globals "Docker" $.Docker }}
+{{- $_ := set $globals "CurrentContainer" (where $globals.containers "ID" $globals.Docker.CurrentContainerID | first) }}
+{{- $_ := set $globals "default_cert_ok" (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
+{{- $_ := set $globals "external_http_port" (coalesce $globals.Env.HTTP_PORT "80") }}
+{{- $_ := set $globals "external_https_port" (coalesce $globals.Env.HTTPS_PORT "443") }}
+{{- $_ := set $globals "sha1_upstream_name" (parseBool (coalesce $globals.Env.SHA1_UPSTREAM_NAME "false")) }}
+{{- $_ := set $globals "default_root_response" (coalesce $globals.Env.DEFAULT_ROOT "404") }}
+{{- $_ := set $globals "trust_downstream_proxy" (parseBool (coalesce $globals.Env.TRUST_DOWNSTREAM_PROXY "true")) }}
+{{- $_ := set $globals "access_log" (or (and (not $globals.Env.DISABLE_ACCESS_LOGS) "access_log /var/log/nginx/access.log vhost;") "") }}
+{{- $_ := set $globals "enable_ipv6" (parseBool (coalesce $globals.Env.ENABLE_IPV6 "false")) }}
+{{- $_ := set $globals "ssl_policy" (or ($globals.Env.SSL_POLICY) "Mozilla-Intermediate") }}
+{{- $_ := set $globals "vhosts" (dict) }}
+{{- $_ := set $globals "networks" (dict) }}
+# Networks available to the container running docker-gen (which are assumed to
+# match the networks available to the container running nginx):
+{{- /*
+     * Note: $globals.CurrentContainer may be nil in some circumstances due to
+     * <https://github.com/nginx-proxy/docker-gen/issues/458>.  For more context
+     * see <https://github.com/nginx-proxy/nginx-proxy/issues/2189>.
+     */}}
+{{- if $globals.CurrentContainer }}
+    {{- range sortObjectsByKeysAsc $globals.CurrentContainer.Networks "Name" }}
+        {{- $_ := set $globals.networks .Name . }}
+#     {{ .Name }}
+    {{- else }}
+#     (none)
+    {{- end }}
+{{- else }}
+# /!\ WARNING: Failed to find the Docker container running docker-gen.  All
+#              upstream (backend) application containers will appear to be
+#              unreachable.  Try removing the -only-exposed and -only-published
+#              arguments to docker-gen if you pass either of those.  See
+#              <https://github.com/nginx-proxy/docker-gen/issues/458>.
+{{- end }}
+
+{{- /*
+     * Template used as a function to get a container's IP address.  This
+     * template only outputs debug comments; the IP address is "returned" by
+     * storing the value in the provided dot dict.
+     *
+     * The provided dot dict is expected to have the following entries:
+     *   - "globals": Global values.
+     *   - "container": The container's RuntimeContainer struct.
+     *
+     * The return value will be added to the dot dict with key "ip".
+     */}}
+{{- define "container_ip" }}
+    {{- $ip := "" }}
+    #     networks:
+    {{- range sortObjectsByKeysAsc $.container.Networks "Name" }}
+        {{- /*
+             * TODO: Only ignore the "ingress" network for Swarm tasks (in case
+             * the user is not using Swarm mode and names a network "ingress").
+             */}}
+        {{- if eq .Name "ingress" }}
+    #         {{ .Name }} (ignored)
+            {{- continue }}
+        {{- end }}
+        {{- if eq .Name "host" }}
+            {{- /* Handle containers in host nework mode */}}
+            {{- if (index $.globals.networks "host") }}
+    #         both container and proxy are in host network mode, using localhost IP
+                {{- $ip = "127.0.0.1" }}
+                {{- continue }}
+            {{- end }}
+            {{- range sortObjectsByKeysAsc $.globals.CurrentContainer.Networks "Name" }}
+                {{- if and . .Gateway (not .Internal) }}
+    #         container is in host network mode, using {{ .Name }} gateway IP
+                    {{- $ip = .Gateway }}
+                    {{- break }}
+                {{- end }}
+            {{- end }}
+            {{- if $ip }}
+                {{- continue }}
+            {{- end }}
+        {{- end }}
+        {{- if and (not (index $.globals.networks .Name)) (not $.globals.networks.host) }}
+    #         {{ .Name }} (unreachable)
+            {{- continue }}
+        {{- end }}
+        {{- /*
+             * Do not emit multiple `server` directives for this container if it
+             * is reachable over multiple networks.  This avoids accidentally
+             * inflating the effective round-robin weight of a server due to the
+             * redundant upstream addresses that nginx sees as belonging to
+             * distinct servers.
+             */}}
+        {{- if $ip }}
+    #         {{ .Name }} (ignored; reachable but redundant)
+            {{- continue }}
+        {{- end }}
+    #         {{ .Name }} (reachable)
+        {{- if and . .IP }}
+            {{- $ip = .IP }}
+        {{- else }}
+    #             /!\ No IP for this network!
+        {{- end }}
+    {{- else }}
+    #         (none)
+    {{- end }}
+    #     IP address: {{ if $ip }}{{ $ip }}{{ else }}(none usable){{ end }}
+    {{- $_ := set $ "ip" $ip }}
+{{- end }}
+
+{{- /*
+     * Template used as a function to get the port of the server in the given
+     * container.  This template only outputs debug comments; the port is
+     * "returned" by storing the value in the provided dot dict.
+     *
+     * The provided dot dict is expected to have the following entries:
+     *   - "container": The container's RuntimeContainer struct.
+     *
+     * The return value will be added to the dot dict with key "port".
+     */}}
+{{- define "container_port" }}
+    {{- /* If only 1 port exposed, use that as a default, else 80. */}}
+    #     exposed ports (first ten):{{ range $index, $address := (sortObjectsByKeysAsc $.container.Addresses "Port") }}{{ if lt $index 10 }} {{ $address.Port }}/{{ $address.Proto }}{{ end }}{{ else }} (none){{ end }}
+    {{- $default_port := when (eq (len $.container.Addresses) 1) (first $.container.Addresses).Port "80" }}
+    #     default port: {{ $default_port }}
+    {{- $port := when (eq $.port "default") $default_port (when (eq $.port "legacy") (or $.container.Env.VIRTUAL_PORT $default_port) $.port) }}
+    #     using port: {{ $port }}
+    {{- $addr_obj := where $.container.Addresses "Port" $port | first }}
+    {{- if and $addr_obj $addr_obj.HostPort }}
+    #         /!\ WARNING: Virtual port published on host.  Clients
+    #                      might be able to bypass nginx-proxy and
+    #                      access the container's server directly.
+    {{- end }}
+    {{- $_ := set $ "port" $port }}
+{{- end }}
+
+{{- define "ssl_policy" }}
+    {{- if eq .ssl_policy "Mozilla-Modern" }}
+    ssl_protocols TLSv1.3;
+    {{- /*
+         * This ssl_ciphers directive is not used but necessary to get TLSv1.3 only.
+         * see https://serverfault.com/questions/1023766/nginx-with-only-tls1-3-cipher-suites
+         */}}
+    ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384;
+    ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
+    ssl_prefer_server_ciphers off;
+    {{- else if eq .ssl_policy "Mozilla-Intermediate" }}
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305';
+    ssl_prefer_server_ciphers off;
+    {{- else if eq .ssl_policy "Mozilla-Old" }}
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-TLS13-1-3-2021-06" }}
+    ssl_protocols TLSv1.3;
+    {{- /*
+         * This ssl_ciphers directive is not used but necessary to get TLSv1.3 only.
+         * see https://serverfault.com/questions/1023766/nginx-with-only-tls1-3-cipher-suites
+         */}}
+    ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384;
+    ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-TLS13-1-2-2021-06" }}
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-TLS13-1-2-Res-2021-06" }}
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-TLS13-1-2-Ext1-2021-06" }}
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES128-SHA256:AES256-GCM-SHA384:AES256-SHA256';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-TLS13-1-2-Ext2-2021-06" }}
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-TLS13-1-1-2021-06" }}
+    ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-TLS13-1-0-2021-06" }}
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-FS-1-2-Res-2020-10" }}
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-FS-1-2-Res-2019-08" }}
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-FS-1-2-2019-08" }}
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-FS-1-1-2019-08" }}
+    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-FS-2018-06" }}
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-TLS-1-2-Ext-2018-06" }}
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-TLS-1-2-2017-01" }}
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES128-SHA256:AES256-GCM-SHA384:AES256-SHA256';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-TLS-1-1-2017-01" }}
+    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-2016-08" }}
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-2015-05" }}
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DES-CBC3-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-2015-03" }}
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DHE-DSS-AES128-SHA:DES-CBC3-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- else if eq .ssl_policy "AWS-2015-02" }}
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DHE-DSS-AES128-SHA';
+    ssl_prefer_server_ciphers on;
+    {{- end }}
+{{- end }}
+
+{{- define "location" }}
+    {{- $vpath := .VPath }}
+    {{- $override := printf "/etc/nginx/vhost.d/%s_%s_location_override" .Host (sha1 .Path) }}
+    {{- if and (eq .Path "/") (not (exists $override)) }}
+        {{- $override = printf "/etc/nginx/vhost.d/%s_location_override" .Host }}
+    {{- end }}
+    {{- if exists $override }}
+    include {{ $override }};
+    {{- else }}
+        {{- $keepalive := $vpath.keepalive }}
+    location {{ .Path }} {
+        {{- if eq $vpath.network_tag "internal" }}
+        # Only allow traffic from internal clients
+        include /etc/nginx/network_internal.conf;
+        {{- end }}
+
+        {{ $proto := $vpath.proto }}
+        {{ $upstream := $vpath.upstream }}
+        {{ $dest := $vpath.dest }}
+        {{- if eq $proto "uwsgi" }}
+        include uwsgi_params;
+        uwsgi_pass {{ trim $proto }}://{{ trim $upstream }};
+        {{- else if eq $proto "fastcgi" }}
+            {{- if (exists "/etc/nginx/fastcgi.conf") }}
+        include fastcgi.conf;
+            {{- else if (exists "/etc/nginx/fastcgi_params") }}
+        include fastcgi_params;
+            {{- else }}
+        # neither /etc/nginx/fastcgi.conf nor /etc/nginx/fastcgi_params found, fastcgi won't work
+            {{- end }}
+        root {{ trim .VhostRoot }};
+        fastcgi_pass {{ trim $upstream }};
+            {{- if ne $keepalive "disabled" }}
+        fastcgi_keep_conn on;
+            {{- end }}
+        {{- else if eq $proto "grpc" }}
+        grpc_pass {{ trim $proto }}://{{ trim $upstream }};
+        {{- else if eq $proto "grpcs" }}
+        grpc_pass {{ trim $proto }}://{{ trim $upstream }};
+        {{- else }}
+        proxy_pass {{ trim $proto }}://{{ trim $upstream }}{{ trim $dest }};
+        set $upstream_keepalive {{ if ne $keepalive "disabled" }}true{{ else }}false{{ end }};
+        {{- end }}
+
+        {{- if (exists (printf "/etc/nginx/htpasswd/%s_%s" .Host (sha1 .Path) )) }}
+        auth_basic "Restricted {{ .Host }}{{ .Path }}";
+        auth_basic_user_file {{ (printf "/etc/nginx/htpasswd/%s_%s" .Host (sha1 .Path)) }};
+        {{- else if (exists (printf "/etc/nginx/htpasswd/%s" .Host)) }}
+        auth_basic "Restricted {{ .Host }}";
+        auth_basic_user_file {{ (printf "/etc/nginx/htpasswd/%s" .Host) }};
+        {{- end }}
+
+        {{- if (exists (printf "/etc/nginx/vhost.d/%s_%s_location" .Host (sha1 .Path) )) }}
+        include {{ printf "/etc/nginx/vhost.d/%s_%s_location" .Host (sha1 .Path) }};
+        {{- else if (exists (printf "/etc/nginx/vhost.d/%s_location" .Host)) }}
+        include {{ printf "/etc/nginx/vhost.d/%s_location" .Host}};
+        {{- else if (exists "/etc/nginx/vhost.d/default_location") }}
+        include /etc/nginx/vhost.d/default_location;
+        {{- end }}
+    }
+    {{- end }}
+{{- end }}
+
+{{- define "upstream" }}
+    {{- $path := .Path }}
+    {{- $vpath := .VPath }}
+upstream {{ $vpath.upstream }} {
+    {{- $servers := 0 }}
+    {{- $loadbalance := $vpath.loadbalance }}
+    {{- if $loadbalance }}
+    # From the container's loadbalance label:
+    {{ $loadbalance }}
+    {{- end }}
+    {{- range $port, $containers := $vpath.ports }}
+        {{- range $container := $containers }}
+    # Container: {{ $container.Name }}
+            {{- $args := dict "globals" $.globals "container" $container }}
+            {{- template "container_ip" $args }}
+            {{- $ip := $args.ip }}
+            {{- $args = dict "container" $container "path" $path "port" $port }}
+            {{- template "container_port" $args }}
+            {{- if $ip }}
+                {{- $servers = add1 $servers }}
+    server {{ $ip }}:{{ $args.port }};
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- /* nginx-proxy/nginx-proxy#1105 */}}
+    {{- if lt $servers 1 }}
+    # Fallback entry
+    server 127.0.0.1 down;
+    {{- end }}
+    {{- $keepalive := $vpath.keepalive }}
+    {{- if and (ne $keepalive "disabled") (gt $servers 0) }}
+        {{- if eq $keepalive "auto" }}
+    keepalive {{ mul $servers 2 }};
+        {{- else }}
+    keepalive {{ $keepalive }};
+        {{- end }}
+    {{- end }}
+}
+{{- end }}
+
+# If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
+# scheme used to connect to this server
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+    default {{ if $globals.trust_downstream_proxy }}$http_x_forwarded_proto{{ else }}$scheme{{ end }};
+    '' $scheme;
+}
+
+map $http_x_forwarded_host $proxy_x_forwarded_host {
+    default {{ if $globals.trust_downstream_proxy }}$http_x_forwarded_host{{ else }}$host{{ end }};
+    '' $host;
+}
+
+# If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
+# server port the client connected to
+map $http_x_forwarded_port $proxy_x_forwarded_port {
+    default {{ if $globals.trust_downstream_proxy }}$http_x_forwarded_port{{ else }}$server_port{{ end }};
+    '' $server_port;
+}
+
+# Include the port in the Host header sent to the container if it is non-standard
+map $server_port $host_port {
+    default :$server_port;
+    80 '';
+    443 '';
+}
+
+# If the request from the downstream client has an "Upgrade:" header (set to any
+# non-empty value), pass "Connection: upgrade" to the upstream (backend) server.
+# Otherwise, the value for the "Connection" header depends on whether the user
+# has enabled keepalive to the upstream server.
+map $http_upgrade $proxy_connection {
+    default upgrade;
+    '' $proxy_connection_noupgrade;
+}
+map $upstream_keepalive $proxy_connection_noupgrade {
+    # Preserve nginx's default behavior (send "Connection: close").
+    default close;
+    # Use an empty string to cancel nginx's default behavior.
+    true '';
+}
+# Abuse the map directive (see <https://stackoverflow.com/q/14433309>) to ensure
+# that $upstream_keepalive is always defined.  This is necessary because:
+#   - The $proxy_connection variable is indirectly derived from
+#     $upstream_keepalive, so $upstream_keepalive must be defined whenever
+#     $proxy_connection is resolved.
+#   - The $proxy_connection variable is used in a proxy_set_header directive in
+#     the http block, so it is always fully resolved for every request -- even
+#     those where proxy_pass is not used (e.g., unknown virtual host).
+map "" $upstream_keepalive {
+    # The value here should not matter because it should always be overridden in
+    # a location block (see the "location" template) for all requests where the
+    # value actually matters.
+    default false;
+}
+
+# Apply fix for very long server names
+server_names_hash_bucket_size 128;
+
+# Default dhparam
+{{- if (exists "/etc/nginx/dhparam/dhparam.pem") }}
+ssl_dhparam /etc/nginx/dhparam/dhparam.pem;
+{{- end }}
+
+# Set appropriate X-Forwarded-Ssl header based on $proxy_x_forwarded_proto
+map $proxy_x_forwarded_proto $proxy_x_forwarded_ssl {
+    default off;
+    https on;
+}
+
+gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+
+{{- /* See https://nginx.org/en/docs/http/ngx_http_log_module.html#log_format for details and variables
+     * LOG_FORMAT_ESCAPE sets the escape part of the log format
+     * LOG_FORMAT        sets the log format
+     */}}
+{{- $logEscape := printf "escape=%s" (or $globals.Env.LOG_FORMAT_ESCAPE "default") }}
+{{- $logFormat := or $globals.Env.LOG_FORMAT `$host $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$upstream_addr"` }}
+
+{{- if parseBool (or $globals.Env.LOG_JSON "false") }}
+    {{- /* LOG_JSON is a shorthand
+        * that sets logging defaults to JSON format
+        */}}
+# JSON Logging enabled (via LOG_JSON env variable)
+    {{- $logEscape = printf "escape=%s" (or $globals.Env.LOG_FORMAT_ESCAPE "json") }}
+    {{- $logFormat = or $globals.Env.LOG_FORMAT `{"time_local":"$time_iso8601","client_ip":"$http_x_forwarded_for","remote_addr":"$remote_addr","request":"$request","status":"$status","body_bytes_sent":"$body_bytes_sent","request_time":"$request_time","upstream_response_time":"$upstream_response_time","upstream_addr":"$upstream_addr","http_referrer":"$http_referer","http_user_agent":"$http_user_agent","request_id":"$request_id"}` }}
+{{- end }}
+
+log_format vhost {{ $logEscape }} '{{ or $globals.Env.LOG_FORMAT $logFormat }}';
+
+access_log off;
+
+{{- template "ssl_policy" (dict "ssl_policy" $globals.ssl_policy) }}
+error_log /dev/stderr;
+
+{{- if $globals.Env.RESOLVERS }}
+resolver {{ $globals.Env.RESOLVERS }};
+{{- end }}
+
+{{- if (exists "/etc/nginx/proxy.conf") }}
+include /etc/nginx/proxy.conf;
+{{- else }}
+# HTTP 1.1 support
+proxy_http_version 1.1;
+proxy_set_header Host $host$host_port;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $proxy_connection;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Host $proxy_x_forwarded_host;
+proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
+proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
+proxy_set_header X-Original-URI $request_uri;
+
+# Mitigate httpoxy attack (see README for details)
+proxy_set_header Proxy "";
+{{- end }}
+
+{{- /* Precompute and store some information about vhost that use VIRTUAL_HOST_MULTIPORTS. */}}
+{{- range $vhosts_yaml, $containers := groupBy $globals.containers "Env.VIRTUAL_HOST_MULTIPORTS" }}
+    {{- /* Print a warning in the config if VIRTUAL_HOST_MULTIPORTS can't be parsed. */}}
+    {{- $parsedVhosts := fromYaml $vhosts_yaml }}
+    {{- if (empty $parsedVhosts) }}
+        {{- $containerNames := list }}
+        {{- range $container := $containers }}
+            {{- $containerNames = append $containerNames $container.Name }}
+        {{- end }}
+# /!\ WARNING: the VIRTUAL_HOST_MULTIPORTS environment variable used for {{ len $containerNames | plural "this container" "those containers" }} is not a valid YAML string:
+# {{ $containerNames | join ", " }}
+        {{- continue }}
+    {{- end }}
+
+    {{- range $hostname, $vhost := $parsedVhosts }}
+        {{- $vhost_data := when (hasKey $globals.vhosts $hostname) (get $globals.vhosts $hostname) (dict) }}
+        {{- $paths := coalesce $vhost_data.paths (dict) }}
+
+        {{- if (empty $vhost) }}
+            {{ $vhost = dict "/" (dict) }}
+        {{- end }}
+
+        {{- range $path, $vpath := $vhost }}
+            {{- if (empty $vpath) }}
+                {{- $vpath = dict "dest" "" "port" "default" }}
+            {{- end }}
+            {{- $dest := coalesce $vpath.dest "" }}
+            {{- $port := when (hasKey $vpath "port") (toString $vpath.port) "default" }}
+            {{- $path_data := when (hasKey $paths $path) (get $paths $path) (dict) }}
+            {{- $path_ports := when (hasKey $path_data "ports") (get $path_data "ports") (dict) }}
+            {{- $path_port_containers := when (hasKey $path_ports $port) (get $path_ports $port) (list) }}
+            {{- $path_port_containers = concat $path_port_containers $containers }}
+            {{- $_ := set $path_ports $port $path_port_containers }}
+            {{- $_ := set $path_data "ports" $path_ports }}
+            {{- if (not (hasKey $path_data "dest")) }}
+                {{- $_ := set $path_data "dest" $dest }}
+            {{- end }}
+            {{- $_ := set $paths $path $path_data }}
+        {{- end }}
+        {{- $_ := set $vhost_data "paths" $paths }}
+        {{- $is_regexp := hasPrefix "~" $hostname }}
+        {{- $_ := set $vhost_data "upstream_name" (when (or $is_regexp $globals.sha1_upstream_name) (sha1 $hostname) $hostname) }}
+        {{- $_ := set $globals.vhosts $hostname $vhost_data }}
+    {{- end }}
+{{- end }}
+
+{{- /* Precompute and store some information about vhost that use VIRTUAL_HOST. */}}
+{{- range $hostname, $containers := groupByMulti $globals.containers "Env.VIRTUAL_HOST" "," }}
+    {{- /* Ignore containers with VIRTUAL_HOST set to the empty string. */}}
+    {{- $hostname = trim $hostname }}
+    {{- if not $hostname }}
+        {{- continue }}
+    {{- end }}
+
+    {{- /* Drop containers with both VIRTUAL_HOST and VIRTUAL_HOST_MULTIPORTS set
+         * (VIRTUAL_HOST_MULTIPORTS takes precedence thanks to the previous loop).
+         */}}
+    {{- range $_, $containers_to_drop := groupBy $containers "Env.VIRTUAL_HOST_MULTIPORTS" }}
+        {{- range $container := $containers_to_drop }}
+            {{- $containers = without $containers $container }}
+        {{- end }}
+    {{- end }}
+    {{- if (eq (len $containers) 0) }}
+        {{- continue }}
+    {{- end }}
+
+    {{- $vhost_data := when (hasKey $globals.vhosts $hostname) (get $globals.vhosts $hostname) (dict) }}
+    {{- $paths := coalesce $vhost_data.paths (dict) }}
+
+    {{- $tmp_paths := groupByWithDefault $containers "Env.VIRTUAL_PATH" "/" }}
+
+    {{- range $path, $containers := $tmp_paths }}
+        {{- $dest := or (first (groupByKeys $containers "Env.VIRTUAL_DEST")) "" }}
+        {{- $port := "legacy" }}
+        {{- $path_data := when (hasKey $paths $path) (get $paths $path) (dict) }}
+        {{- $path_ports := when (hasKey $path_data "ports") (get $path_data "ports") (dict) }}
+        {{- $path_port_containers := when (hasKey $path_ports $port) (get $path_ports $port) (list) }}
+        {{- $path_port_containers = concat $path_port_containers $containers }}
+        {{- $_ := set $path_ports $port $path_port_containers }}
+        {{- $_ := set $path_data "ports" $path_ports }}
+        {{- if (not (hasKey $path_data "dest")) }}
+            {{- $_ := set $path_data "dest" $dest }}
+        {{- end }}
+        {{- $_ := set $paths $path $path_data }}
+    {{- end }}
+    {{- $_ := set $vhost_data "paths" $paths }}
+    {{- $is_regexp := hasPrefix "~" $hostname }}
+    {{- $_ := set $vhost_data "upstream_name" (when (or $is_regexp $globals.sha1_upstream_name) (sha1 $hostname) $hostname) }}
+    {{- $_ := set $globals.vhosts $hostname $vhost_data }}
+{{- end }}
+
+{{- /* Loop over $globals.vhosts and update it with the remaining informations about each vhost. */}}
+{{- range $hostname, $vhost_data := $globals.vhosts }}
+    {{- $vhost_containers := list }}
+    {{- range $path, $vpath_data := $vhost_data.paths }}
+        {{- $vpath_containers := list }}
+        {{- range $port, $vport_containers := $vpath_data.ports }}
+            {{ $vpath_containers = concat $vpath_containers $vport_containers }}
+        {{- end }}
+
+        {{- /* Get the VIRTUAL_PROTO defined by containers w/ the same vhost-vpath, falling back to "http". */}}
+        {{- $proto := trim (or (first (groupByKeys $vpath_containers "Env.VIRTUAL_PROTO")) "http") }}
+        {{- /* Get the NETWORK_ACCESS defined by containers w/ the same vhost, falling back to "external". */}}
+        {{- $network_tag := or (first (groupByKeys $vpath_containers "Env.NETWORK_ACCESS")) "external" }}
+
+        {{- $loadbalance := first (keys (groupByLabel $vpath_containers "com.github.nginx-proxy.nginx-proxy.loadbalance")) }}
+        {{- $keepalive := coalesce (first (keys (groupByLabel $vpath_containers "com.github.nginx-proxy.nginx-proxy.keepalive"))) "disabled" }}
+
+        {{- $upstream := $vhost_data.upstream_name }}
+        {{- if (not (eq $path "/")) }}
+            {{- $sum := sha1 $path }}
+            {{- $upstream = printf "%s-%s" $upstream $sum }}
+        {{- end }}
+
+        {{- $_ := set $vpath_data "proto" $proto }}
+        {{- $_ := set $vpath_data "network_tag" $network_tag }}
+        {{- $_ := set $vpath_data "upstream" $upstream }}
+        {{- $_ := set $vpath_data "loadbalance" $loadbalance }}
+        {{- $_ := set $vpath_data "keepalive" $keepalive }}
+        {{- $_ := set $vhost_data.paths $path $vpath_data }}
+
+        {{ $vhost_containers = concat $vhost_containers $vpath_containers }}
+    {{- end }}
+
+    {{- $certName := first (groupByKeys $vhost_containers "Env.CERT_NAME") }}
+    {{- $vhostCert := closest (dir "/etc/nginx/certs") (printf "%s.crt" $hostname) }}
+    {{- $vhostCert = trimSuffix ".crt" $vhostCert }}
+    {{- $vhostCert = trimSuffix ".key" $vhostCert }}
+    {{- $cert := or $certName $vhostCert }}
+    {{- $cert_ok := and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert)) }}
+
+    {{- $default := eq $globals.Env.DEFAULT_HOST $hostname }}
+    {{- $https_method := or (first (groupByKeys $vhost_containers "Env.HTTPS_METHOD")) $globals.Env.HTTPS_METHOD "redirect" }}
+    {{- $enable_http_on_missing_cert := parseBool (or (first (groupByKeys $vhost_containers "Env.ENABLE_HTTP_ON_MISSING_CERT")) $globals.Env.ENABLE_HTTP_ON_MISSING_CERT "true") }}
+    {{- /* When the certificate is missing we want to ensure that HTTP is enabled; hence switching from 'nohttp' or 'redirect' to 'noredirect' */}}
+    {{- if (and $enable_http_on_missing_cert (not $cert_ok) (or (eq $https_method "nohttp") (eq $https_method "redirect"))) }}
+        {{- $https_method = "noredirect" }}
+    {{- end }}
+    {{- $http2_enabled := parseBool (or (first (keys (groupByLabel $vhost_containers "com.github.nginx-proxy.nginx-proxy.http2.enable"))) $globals.Env.ENABLE_HTTP2 "true")}}
+    {{- $http3_enabled := parseBool (or (first (keys (groupByLabel $vhost_containers "com.github.nginx-proxy.nginx-proxy.http3.enable"))) $globals.Env.ENABLE_HTTP3 "false")}}
+    {{- $acme_http_challenge := or (first (groupByKeys $vhost_containers "Env.ACME_HTTP_CHALLENGE_LOCATION")) $globals.Env.ACME_HTTP_CHALLENGE_LOCATION "true" }}
+    {{- $acme_http_challenge_legacy := eq $acme_http_challenge "legacy" }}
+    {{- $acme_http_challenge_enabled := false }}
+    {{- if (not $acme_http_challenge_legacy) }}
+        {{- $acme_http_challenge_enabled = parseBool $acme_http_challenge }}
+    {{- end }}
+
+    {{- /* Get the SERVER_TOKENS defined by containers w/ the same vhost, falling back to "". */}}
+    {{- $server_tokens := trim (or (first (groupByKeys $vhost_containers "Env.SERVER_TOKENS")) "") }}
+
+    {{- /* Get the SSL_POLICY defined by containers w/ the same vhost, falling back to empty string (use default). */}}
+    {{- $ssl_policy := or (first (groupByKeys $vhost_containers "Env.SSL_POLICY")) "" }}
+
+    {{- /* Get the HSTS defined by containers w/ the same vhost, falling back to "max-age=31536000". */}}
+    {{- $hsts := or (first (groupByKeys $vhost_containers "Env.HSTS")) (or $globals.Env.HSTS "max-age=31536000") }}
+
+    {{- /* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
+    {{- $vhost_root := or (first (groupByKeys $vhost_containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
+
+    {{- $vhost_data = merge $vhost_data (dict
+        "cert" $cert
+        "cert_ok" $cert_ok
+        "default" $default
+        "hsts" $hsts
+        "https_method" $https_method
+        "http2_enabled" $http2_enabled
+        "http3_enabled" $http3_enabled
+        "acme_http_challenge_legacy" $acme_http_challenge_legacy
+        "acme_http_challenge_enabled" $acme_http_challenge_enabled
+        "server_tokens" $server_tokens
+        "ssl_policy" $ssl_policy
+        "vhost_root" $vhost_root
+    ) }}
+    {{- $_ := set $globals.vhosts $hostname $vhost_data }}
+{{- end }}
+
+
+{{- /*
+     * If needed, create a catch-all fallback server to send an error code to
+     * clients that request something from an unknown vhost.
+     *
+     * This server must appear first in the generated config because nginx uses
+     * the first `server` directive to handle requests that don't match any of
+     * the other `server` directives.  An alternative approach would be to add
+     * the `default_server` option to the `listen` directives inside this
+     * `server`, but some users inject a custom `server` directive that uses
+     * `default_server`.  Using `default_server` here would cause nginx to fail
+     * to start for those users.  See
+     * <https://github.com/nginx-proxy/nginx-proxy/issues/2212>.
+     */}}
+{{- block "fallback_server" $globals }}
+    {{- $globals := . }}
+    {{- $http_exists := false }}
+    {{- $https_exists := false }}
+    {{- $default_http_exists := false }}
+    {{- $default_https_exists := false }}
+    {{- $http3_enabled := false }}
+    {{- range $vhost := $globals.vhosts }}
+        {{- $http := ne $vhost.https_method "nohttp" }}
+        {{- $https := ne $vhost.https_method "nohttps" }}
+        {{- $http_exists = or $http_exists $http }}
+        {{- $https_exists = or $https_exists $https }}
+        {{- $default_http_exists = or $default_http_exists (and $http $vhost.default) }}
+        {{- $default_https_exists = or $default_https_exists (and $https $vhost.default) }}
+        {{- $http3_enabled = or $http3_enabled $vhost.http3_enabled }}
+    {{- end }}
+    {{- $fallback_http := not $default_http_exists }}
+    {{- $fallback_https := not $default_https_exists }}
+    {{- /*
+         * If there are no vhosts at all, create fallbacks for both plain http
+         * and https so that clients get something more useful than a connection
+         * refused error.
+         */}}
+    {{- if and (not $http_exists) (not $https_exists) }}
+        {{- $fallback_https = true }}
+    {{- end }}
+    {{- if or $fallback_http $fallback_https }}
+server {
+    server_name _; # This is just an invalid value which will never trigger on a real hostname.
+    server_tokens off;
+    {{ $globals.access_log }}
+    http2 on;
+        {{- if $fallback_http }}
+    listen {{ $globals.external_http_port }}; {{- /* Do not add `default_server` (see comment above). */}}
+                {{- if $globals.enable_ipv6 }}
+    listen [::]:{{ $globals.external_http_port }}; {{- /* Do not add `default_server` (see comment above). */}}
+                {{- end }}
+        {{- end }}
+        {{- if $fallback_https }}
+    listen {{ $globals.external_https_port }} ssl; {{- /* Do not add `default_server` (see comment above). */}}
+            {{- if $globals.enable_ipv6 }}
+    listen [::]:{{ $globals.external_https_port }} ssl; {{- /* Do not add `default_server` (see comment above). */}}
+            {{- end }}
+            {{- if $http3_enabled }}
+    http3 on;
+    listen {{ $globals.external_https_port }} quic reuseport; {{- /* Do not add `default_server` (see comment above). */}}
+                {{- if $globals.enable_ipv6 }}
+    listen [::]:{{ $globals.external_https_port }} quic reuseport; {{- /* Do not add `default_server` (see comment above). */}}
+                {{- end }}
+            {{- end }}
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+        {{- end }}
+        {{- if $globals.default_cert_ok }}
+    ssl_certificate /etc/nginx/certs/default.crt;
+    ssl_certificate_key /etc/nginx/certs/default.key;
+        {{- else }}
+    # No default.crt certificate found for this vhost, so force nginx to emit a
+    # TLS error if the client connects via https.
+    {{- /* See the comment in the main `server` directive for rationale. */}}
+    ssl_ciphers aNULL;
+    set $empty "";
+    ssl_certificate data:$empty;
+    ssl_certificate_key data:$empty;
+    if ($https) {
+        return 444;
+    }
+        {{- end }}
+
+        {{- if (exists "/usr/share/nginx/html/errors/50x.html") }}
+    error_page 500 502 503 504 /50x.html;
+    location /50x.html {
+        root /usr/share/nginx/html/errors;
+        internal;
+    }
+        {{- end }}
+    location ^~ / {
+        return 503;
+    }
+}
+    {{- end }}
+{{- end }}
+
+{{- range $hostname, $vhost := $globals.vhosts }}
+    {{- $default_server := when $vhost.default "default_server" "" }}
+
+    {{- range $path, $vpath := $vhost.paths }}
+# {{ $hostname }}{{ $path }}
+        {{ template "upstream" (dict "globals" $globals "Path" $path "VPath" $vpath) }}
+    {{- end }}
+
+    {{- if (eq $vhost.https_method "redirect") }}
+server {
+    server_name {{ $hostname }};
+        {{- if $vhost.server_tokens }}
+    server_tokens {{ $vhost.server_tokens }};
+        {{- end }}
+    {{ $globals.access_log }}
+    listen {{ $globals.external_http_port }} {{ $default_server }};
+        {{- if $globals.enable_ipv6 }}
+    listen [::]:{{ $globals.external_http_port }} {{ $default_server }};
+        {{- end }}
+
+        {{- if (or $vhost.acme_http_challenge_legacy $vhost.acme_http_challenge_enabled) }}
+    # Do not HTTPS redirect Let's Encrypt ACME challenge
+    location ^~ /.well-known/acme-challenge/ {
+        auth_basic off;
+        auth_request off;
+        allow all;
+        root /usr/share/nginx/html;
+        try_files $uri =404;
+        break;
+    }
+        {{- end }}
+
+    location / {
+        {{- if eq $globals.external_https_port "443" }}
+        return 301 https://$host$request_uri;
+        {{- else }}
+        return 301 https://$host:{{ $globals.external_https_port }}$request_uri;
+        {{- end }}
+    }
+}
+    {{- end }}
+
+server {
+    server_name {{ $hostname }};
+    {{- if $vhost.server_tokens }}
+    server_tokens {{ $vhost.server_tokens }};
+    {{- end }}
+    {{ $globals.access_log }}
+    {{- if $vhost.http2_enabled }}
+    http2 on;
+    {{- end }}
+    {{- if or (eq $vhost.https_method "nohttps") (eq $vhost.https_method "noredirect") }}
+    listen {{ $globals.external_http_port }} {{ $default_server }};
+        {{- if $globals.enable_ipv6 }}
+    listen [::]:{{ $globals.external_http_port }} {{ $default_server }};
+        {{- end }}
+
+        {{- if (and (eq $vhost.https_method "noredirect") $vhost.acme_http_challenge_enabled) }}
+    location /.well-known/acme-challenge/ {
+        auth_basic off;
+        allow all;
+        root /usr/share/nginx/html;
+        try_files $uri =404;
+        break;
+    }
+        {{- end }}
+    {{- end }}
+    {{- if ne $vhost.https_method "nohttps" }}
+    listen {{ $globals.external_https_port }} ssl {{ $default_server }};
+        {{- if $globals.enable_ipv6 }}
+    listen [::]:{{ $globals.external_https_port }} ssl {{ $default_server }};
+        {{- end }}
+
+        {{- if $vhost.http3_enabled }}
+    http3 on;
+    add_header alt-svc 'h3=":{{ $globals.external_https_port }}"; ma=86400;';
+    listen {{ $globals.external_https_port }} quic {{ $default_server }};
+            {{- if $globals.enable_ipv6 }}
+    listen [::]:{{ $globals.external_https_port }} quic {{ $default_server }};
+            {{- end }}
+        {{- end }}
+
+        {{- if $vhost.cert_ok }}
+            {{- template "ssl_policy" (dict "ssl_policy" $vhost.ssl_policy) }}
+
+    ssl_session_timeout 5m;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $vhost.cert) }};
+    ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $vhost.cert) }};
+
+            {{- if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $vhost.cert)) }}
+    ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $vhost.cert }};
+            {{- end }}
+
+            {{- if (exists (printf "/etc/nginx/certs/%s.chain.pem" $vhost.cert)) }}
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.pem" $vhost.cert }};
+            {{- end }}
+
+            {{- if (not (or (eq $vhost.https_method "noredirect") (eq $vhost.hsts "off"))) }}
+    set $sts_header "";
+    if ($https) {
+        set $sts_header "{{ trim $vhost.hsts }}";
+    }
+    add_header Strict-Transport-Security $sts_header always;
+            {{- end }}
+        {{- else if $globals.default_cert_ok }}
+    # No certificate found for this vhost, so use the default certificate and
+    # return an error code if the user connects via https.
+    ssl_certificate /etc/nginx/certs/default.crt;
+    ssl_certificate_key /etc/nginx/certs/default.key;
+    if ($https) {
+        return 500;
+    }
+        {{- else }}
+    # No certificate found for this vhost, so force nginx to emit a TLS error if
+    # the client connects via https.
+            {{- /*
+                 * The alternative is to not provide an https server for this
+                 * vhost, which would either cause the user to see the wrong
+                 * vhost (if there is another vhost with a certificate) or a
+                 * connection refused error (if there is no other vhost with a
+                 * certificate).  A TLS error is easier to troubleshoot, and is
+                 * safer than serving the wrong vhost.  Also see
+                 * <https://serverfault.com/a/1044022>.
+                 */}}
+    ssl_ciphers aNULL;
+    set $empty "";
+    ssl_certificate data:$empty;
+    ssl_certificate_key data:$empty;
+    if ($https) {
+        return 444;
+    }
+        {{- end }}
+    {{- end }}
+
+    {{- if (exists (printf "/etc/nginx/vhost.d/%s" $hostname)) }}
+    include {{ printf "/etc/nginx/vhost.d/%s" $hostname }};
+    {{- else if (exists "/etc/nginx/vhost.d/default") }}
+    include /etc/nginx/vhost.d/default;
+    {{- end }}
+
+    {{- range $path, $vpath := $vhost.paths }}
+        {{- template "location" (dict
+            "Path" $path
+            "Host" $hostname
+            "VhostRoot" $vhost.vhost_root
+            "VPath" $vpath
+        ) }}
+    {{- end }}
+
+    {{- if and (not (contains $vhost.paths "/")) (ne $globals.default_root_response "none")}}
+    location / {
+        return {{ $globals.default_root_response }};
+    }
+    {{- end }}
+}
+{{- end }}


### PR DESCRIPTION
Add Docker Compose for HTTPS support

* Use nginx-proxy and acme-companion
* Automated creation and renewal of Let's Encrypt certificates
* Automated reload of Nginx config upon certificate creation/renewal
* Achieves an A+ on the Qualys SSL Test
* Separate docker-gen container to avoid exposing docker.sock

Fixes #5 - At least for now, I'll open a different PR to parameterise the port  