### PR TITLE
JSON file is parsed and used if it exists

### DIFF
--- a/config.go
+++ b/config.go
@@ -57,7 +57,9 @@ func getRelayListFromEnvOrFile(envKey, fileKey string) []string {
 	filePath := getEnv(fileKey)
 
 	if filePath != "" {
-		return getRelayListFromFile(filePath)
+		if _, err := os.Stat(filePath); err == nil {
+			return getRelayListFromFile(filePath)
+		}
 	}
 
 	if envValue != "" {

--- a/config.go
+++ b/config.go
@@ -54,13 +54,14 @@ type AwsConfig struct {
 
 func getRelayListFromEnvOrFile(envKey, fileKey string) []string {
 	envValue := getEnv(envKey)
-	if envValue != "" {
-		return getRelayList(envValue)
-	}
-
 	filePath := getEnv(fileKey)
+
 	if filePath != "" {
 		return getRelayListFromFile(filePath)
+	}
+
+	if envValue != "" {
+		return getRelayList(envValue)
 	}
 
 	return []string{}
@@ -127,7 +128,13 @@ func getRelayListFromFile(filePath string) []string {
 	}
 
 	for i, relay := range relayList {
-		relayList[i] = "wss://" + strings.TrimSpace(relay)
+		relay = strings.TrimSpace(relay)
+		if strings.HasPrefix(relay, "wss://") {
+			relay = strings.TrimPrefix(relay, "wss://")
+		} else if strings.HasPrefix(relay, "ws://") {
+			relay = strings.TrimPrefix(relay, "ws://")
+		}
+		relayList[i] = relay
 	}
 	return relayList
 }

--- a/config.go
+++ b/config.go
@@ -129,10 +129,8 @@ func getRelayListFromFile(filePath string) []string {
 
 	for i, relay := range relayList {
 		relay = strings.TrimSpace(relay)
-		if strings.HasPrefix(relay, "wss://") {
-			relay = strings.TrimPrefix(relay, "wss://")
-		} else if strings.HasPrefix(relay, "ws://") {
-			relay = strings.TrimPrefix(relay, "ws://")
+		if !strings.HasPrefix(relay, "wss://") && !strings.HasPrefix(relay, "ws://") {
+			relay = "wss://" + relay
 		}
 		relayList[i] = relay
 	}


### PR DESCRIPTION
From now on, the JSON file is parsed and used if it exists.

Improve relay list parsing to handle 'wss://' prefixes.

Your question on the last PR was:

> won't this break all the .envs and the existing examples because they don't have wss?

As in the `getRelayList` method, a `wss://` is also placed in front.

The same is done in the `getRelayListFromFile`. The JSON can contain a list with or without `wss://` as a prefix.