### PR TITLE
fix filepath for relays_import for clearification in env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,7 +74,7 @@ INBOX_RELAY_CONNECTION_RATE_LIMITER_MAX_TOKENS=9
 ## Import Settings
 IMPORT_START_DATE="2023-01-20"
 IMPORT_QUERY_INTERVAL_SECONDS=600
-IMPORT_SEED_RELAYS_FILE="relays_blastr.json"
+IMPORT_SEED_RELAYS_FILE="relays_import.json"
 
 ## Backup Settings
 BACKUP_PROVIDER="none" # aws, none (or leave blank to disable)


### PR DESCRIPTION
Content is identical of both files, but I assume for the env var `IMPORT_SEED_RELAYS_FILE` the file `relays_import.json` should be used.