### PR TITLE
feat(lmdb): make LMDB map size configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ RELAY_URL="relay.utxo.one"
 RELAY_PORT=3355
 RELAY_BIND_ADDRESS="0.0.0.0" # Can be set to a specific IP4 or IP6 address ("" for all interfaces)
 DB_ENGINE="badger" # badger, lmdb (lmdb works best with an nvme, otherwise you might have stability issues)
+LMDB_MAPSIZE=0 # 0 for default (currently ~273GB), or set to a different size in bytes, e.g. 10737418240 for 10GB
 BLOSSOM_PATH="blossom/"
 
 ## Private Relay Settings

--- a/README.md
+++ b/README.md
@@ -214,6 +214,27 @@ Once everything is set up, the relay will be running on `localhost:3355` with th
 - `localhost:3355/chat`
 - `localhost:3355/inbox`
 
+## Database
+
+Haven currently supports [BadgerDB](https://github.com/dgraph-io/badger) and [LMDB](https://www.symas.com/mdb) as embedded
+databases, meaning no external database is required.
+
+By default, Haven uses BadgerDB. To switch to LMDB, set the `DB_ENGINE` environment variable to `lmdb` in the `.env` file.
+
+LMDB can be faster than BadgerDB but performs best with NVMe drives and may require fine-tuning based on factors such as
+database size, operating system, file system, and hardware.
+
+### LMDB Map Size
+
+For instance, there is no one-size-fits-all value for LMDB’s map size. Windows and macOS users, in particular, may need
+to adjust the `LMDB_MAPSIZE` environment variable to a value lower than the available free disk space if the default
+value of 273 GB is too high. Otherwise, Haven will fail to bootstrap. Users with large databases may also need to
+increase the `LMDB_MAPSIZE` value above the default. On most systems, the default value should work fine.
+
+Despite the large default value, on most modern systems LMDB will only use the disk space it needs. The map size simply
+defines an upper limit for the database size. For more information about LMDB’s map size, refer to the
+[LMDB documentation](http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5).
+
 ## Blossom Media Server
 
 The outbox relay also functions as a media server for hosting images and videos. You can upload media files to the relay and obtain a shareable link.  

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ import (
 type Config struct {
 	OwnerNpub                        string   `json:"owner_npub"`
 	DBEngine                         string   `json:"db_engine"`
+	LmdbMapSize                      int64    `json:"lmdb_map_size"`
 	RelayURL                         string   `json:"relay_url"`
 	RelayPort                        int      `json:"relay_port"`
 	RelayBindAddress                 string   `json:"relay_bind_address"`
@@ -60,6 +61,7 @@ func loadConfig() Config {
 	return Config{
 		OwnerNpub:                        getEnv("OWNER_NPUB"),
 		DBEngine:                         getEnvString("DB_ENGINE", "lmdb"),
+		LmdbMapSize:                      getEnvInt64("LMDB_MAPSIZE", 0),
 		BlossomPath:                      getEnvString("BLOSSOM_PATH", "blossom"),
 		RelayURL:                         getEnv("RELAY_URL"),
 		RelayPort:                        getEnvInt("RELAY_PORT", 3355),
@@ -134,6 +136,17 @@ func getEnvString(key string, defaultValue string) string {
 func getEnvInt(key string, defaultValue int) int {
 	if value, ok := os.LookupEnv(key); ok {
 		intValue, err := strconv.Atoi(value)
+		if err != nil {
+			panic(err)
+		}
+		return intValue
+	}
+	return defaultValue
+}
+
+func getEnvInt64(key string, defaultValue int64) int64 {
+	if value, ok := os.LookupEnv(key); ok {
+		intValue, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			panic(err)
 		}

--- a/init.go
+++ b/init.go
@@ -18,22 +18,22 @@ import (
 
 var (
 	privateRelay = khatru.NewRelay()
-	privateDB    = getPrivateDB()
+	privateDB    = newDBBackend("db/private")
 )
 
 var (
 	chatRelay = khatru.NewRelay()
-	chatDB    = getChatDB()
+	chatDB    = newDBBackend("db/chat")
 )
 
 var (
 	outboxRelay = khatru.NewRelay()
-	outboxDB    = getOutboxDB()
+	outboxDB    = newDBBackend("db/outbox")
 )
 
 var (
 	inboxRelay = khatru.NewRelay()
-	inboxDB    = getInboxDB()
+	inboxDB    = newDBBackend("db/inbox")
 )
 
 type DBBackend interface {
@@ -46,71 +46,23 @@ type DBBackend interface {
 	Serial() []byte
 }
 
-func getPrivateDB() DBBackend {
+func newDBBackend(path string) DBBackend {
 	switch config.DBEngine {
 	case "lmdb":
-		return &lmdb.LMDBBackend{
-			Path: "db/private",
-		}
+		return newLMDBBackend(path)
 	case "badger":
 		return &badger.BadgerBackend{
-			Path: "db/private",
+			Path: path,
 		}
 	default:
-		return &lmdb.LMDBBackend{
-			Path: "db/private",
-		}
+		return newLMDBBackend(path)
 	}
 }
 
-func getChatDB() DBBackend {
-	switch config.DBEngine {
-	case "lmdb":
-		return &lmdb.LMDBBackend{
-			Path: "db/chat",
-		}
-	case "badger":
-		return &badger.BadgerBackend{
-			Path: "db/chat",
-		}
-	default:
-		return &lmdb.LMDBBackend{
-			Path: "db/chat",
-		}
-	}
-}
-
-func getOutboxDB() DBBackend {
-	switch config.DBEngine {
-	case "lmdb":
-		return &lmdb.LMDBBackend{
-			Path: "db/outbox",
-		}
-	case "badger":
-		return &badger.BadgerBackend{
-			Path: "db/outbox",
-		}
-	default:
-		return &lmdb.LMDBBackend{
-			Path: "db/outbox",
-		}
-	}
-}
-
-func getInboxDB() DBBackend {
-	switch config.DBEngine {
-	case "lmdb":
-		return &lmdb.LMDBBackend{
-			Path: "db/inbox",
-		}
-	case "badger":
-		return &badger.BadgerBackend{
-			Path: "db/inbox",
-		}
-	default:
-		return &lmdb.LMDBBackend{
-			Path: "db/inbox",
-		}
+func newLMDBBackend(path string) *lmdb.LMDBBackend {
+	return &lmdb.LMDBBackend{
+		Path:    path,
+		MapSize: config.LmdbMapSize,
 	}
 }
 


### PR DESCRIPTION
- Resolves known issues on Windows and macOS where the default map size caused failures.
- Supports databases larger than 273 GB by allowing map size adjustments.

Fixes #57